### PR TITLE
Introduce BP_PHP_NGINX_ENABLE_HTTPS to enable https

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,14 @@ the Nginx configuration file.
 
 | Variable | Default |
 | -------- | -------- |
+| `BP_PHP_NGINX_ENABLE_HTTPS`   | false    |
 | `BP_PHP_ENABLE_HTTPS_REDIRECT`   | true    |
 | `BP_PHP_WEB_DIR`    | htdocs    |
+
+Note that for HTTPS workloads, setting `$BP_PHP_NGINX_ENABLE_HTTPS` sets all
+connections to work in SSL mode. You may still need to add a user-included
+config file to provide directives like `ssl_certificate`, `ssl_certificate_key`
+etc.
 
 ## Usage
 

--- a/assets/nginx.conf
+++ b/assets/nginx.conf
@@ -134,7 +134,11 @@ http {
     }
 
     server {
+{{if .EnableHTTPS }}
+        listen       {{"{{"}}env "PORT"{{"}}"}} ssl default_server;
+{{else}}
         listen       {{"{{"}}env "PORT"{{"}}"}}  default_server;
+{{end}}
         server_name localhost;
 
         fastcgi_temp_path      /tmp/nginx_fastcgi 1 2;

--- a/config.go
+++ b/config.go
@@ -21,6 +21,7 @@ var NGINXFPMConfTemplate string
 type NginxConfig struct {
 	UserServerConf       string
 	UserHttpConf         string
+	EnableHTTPS          bool
 	DisableHTTPSRedirect bool
 	AppRoot              string
 	WebDirectory         string
@@ -94,6 +95,17 @@ func (c NginxConfigWriter) Write(workingDir string) (string, error) {
 	}
 	data.WebDirectory = webDir
 	c.logger.Debug.Subprocess(fmt.Sprintf("Web directory: %s", webDir))
+
+	enableHTTPS := false
+	enableHTTPSStr, ok := os.LookupEnv("BP_PHP_NGINX_ENABLE_HTTPS")
+	if ok {
+		enableHTTPS, err = strconv.ParseBool(enableHTTPSStr)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse $BP_PHP_NGINX_ENABLE_HTTPS into boolean: %w", err)
+		}
+	}
+	data.EnableHTTPS = enableHTTPS
+	c.logger.Debug.Subprocess(fmt.Sprintf("Enable NGINX HTTPS: %t", enableHTTPS))
 
 	enableHTTPSRedirect := true
 	enableHTTPSRedirectStr, ok := os.LookupEnv("BP_PHP_ENABLE_HTTPS_REDIRECT")

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -79,6 +79,7 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				"  Setting up the Nginx configuration file",
 				"    Including user-provided Nginx server configuration from: /workspace/.nginx.conf.d/*-server.conf",
 				"    Web directory: htdocs",
+				"    Enable NGINX HTTPS: false",
 				"    Enable HTTPS redirect: true",
 				"    FPM socket: /tmp/php-fpm.socket",
 			))

--- a/integration/offline_test.go
+++ b/integration/offline_test.go
@@ -86,6 +86,7 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 				"  Setting up the Nginx configuration file",
 				"    Including user-provided Nginx server configuration from: /workspace/.nginx.conf.d/*-server.conf",
 				"    Web directory: htdocs",
+				"    Enable NGINX HTTPS: false",
 				"    Enable HTTPS redirect: true",
 				"    FPM socket: /tmp/php-fpm.socket",
 			))


### PR DESCRIPTION
`ssl` directive has been deprecated since 1.15.0,
and is removed in nginx 1.25.1.
This is replaced by the configuration option to add the value `ssl` to the `listen` directive.

In the pre-deprecation world, a user can add a user-defined conf file with the app to turn on ssl. In the new world, since the listen directive is provided as part of the core nginx conf generated by this buildpack, users are left with no option (you can't override a directive).

This change solves the issue by allowing users to set `BP_PHP_NGINX_ENABLE_HTTPS=true`

Fixes https://github.com/paketo-buildpacks/php-web/issues/139
Fixes https://github.com/paketo-buildpacks/php-nginx/issues/21
Fixes failure of https://github.com/paketo-buildpacks/php/pull/724 with env var addition in tests.

Links:
http://hg.nginx.org/nginx/rev/0aaa09927703
http://nginx.org/en/CHANGES
http://nginx.org/en/docs/http/ngx_http_core_module.html#listen

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
